### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -28,7 +28,9 @@ routes = Blueprint("routes", __name__)
 @routes.route("/<path:path>")
 def serve(path):
     frontend_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../frontend/build")
-    file_path = os.path.join(frontend_dir, path)
+    file_path = os.path.normpath(os.path.join(frontend_dir, path))
+    if not file_path.startswith(frontend_dir):
+        return "Forbidden", 403
     if path and os.path.exists(file_path):
         return send_from_directory(frontend_dir, path)
     return send_from_directory(frontend_dir, "index.html")


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/3](https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent any path traversal attacks.

1. Normalize the `file_path` using `os.path.normpath`.
2. Check that the normalized `file_path` starts with the `frontend_dir`.
3. If the check fails, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
