### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -47,9 +47,9 @@ def create_app(config_name=None):
     @app.route("/", defaults={"path": ""})
     @app.route("/<path:path>")
     def serve_frontend(path):
-        file_path = os.path.join(app.static_folder, path)
+        file_path = os.path.normpath(os.path.join(app.static_folder, path))
 
-        if os.path.exists(file_path) and os.path.isfile(file_path):
+        if file_path.startswith(app.static_folder) and os.path.exists(file_path) and os.path.isfile(file_path):
             return send_from_directory(app.static_folder, path)
         else:
             return send_from_directory(app.static_folder, "index.html")


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/12](https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/12)

To fix the problem, we need to ensure that the constructed file path is contained within the `static_folder` directory. This can be achieved by normalizing the path and then checking that it starts with the `static_folder` path. 

1. Normalize the `file_path` using `os.path.normpath`.
2. Check that the normalized `file_path` starts with the `static_folder` path.
3. If the check fails, serve the default `index.html` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
