### PR TITLE
Potential fix for code scanning alert no. 24: URL redirection from remote source

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -43,13 +43,19 @@ def linkedin_auth():
     current_app.logger.info(f"[LinkedIn] Received request to link LinkedIn for GitHub user ID: {github_user_id}")
 
     try:
+        # Validate the GitHub user ID
         user = User.query.filter_by(github_id=github_user_id).first()
-        if user:
-            user.linkedin_token = None
-            user.linkedin_id = None
-            db.session.commit()
-            current_app.logger.info(f"[LinkedIn] Cleared LinkedIn token and ID for GitHub user {github_user_id}")
+        if not user:
+            current_app.logger.warning(f"[LinkedIn] Invalid GitHub user ID: {github_user_id}")
+            return jsonify({"error": "Invalid GitHub user ID"}), 400
 
+        # Clear LinkedIn token and ID for the user
+        user.linkedin_token = None
+        user.linkedin_id = None
+        db.session.commit()
+        current_app.logger.info(f"[LinkedIn] Cleared LinkedIn token and ID for GitHub user {github_user_id}")
+
+        # Construct the LinkedIn authorization URL
         scope = "w_member_social"
         linkedin_auth_url = (
             f"https://www.linkedin.com/oauth/v2/authorization"


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/24](https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/24)

To fix the issue, we need to validate the `github_user_id` parameter before incorporating it into the `linkedin_auth_url`. Since `github_user_id` is expected to match a GitHub user in the database, we can ensure it is valid by checking its existence in the database. If the `github_user_id` is invalid or not found, we should reject the request or redirect to a safe default URL.

Additionally, we should ensure that the `linkedin_auth_url` is constructed securely and does not allow any unintended manipulation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
