### PR TITLE
Potential fix for code scanning alert no. 24: URL redirection from remote source

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -39,7 +39,10 @@ def serve(path):
 # -------------------- LINKEDIN AUTHENTICATION -------------------- #
 @routes.route("/auth/linkedin")
 def linkedin_auth():
-    github_user_id = request.args.get("github_user_id", "test")
+    github_user_id = request.args.get("github_user_id", "test").strip()
+    if not github_user_id.isalnum():
+        current_app.logger.warning(f"[LinkedIn] Invalid GitHub user ID format: {github_user_id}")
+        return jsonify({"error": "Invalid GitHub user ID format"}), 400
     current_app.logger.info(f"[LinkedIn] Received request to link LinkedIn for GitHub user ID: {github_user_id}")
 
     try:
@@ -74,6 +77,10 @@ def linkedin_auth():
         current_app.logger.info(f"[DEBUG] github_user_id: {repr(github_user_id)}")
         current_app.logger.info(f"[DEBUG] Full LinkedIn URL: {repr(linkedin_auth_url)}")
 
+        # Validate the constructed URL to ensure it adheres to the expected LinkedIn structure
+        if not linkedin_auth_url.startswith("https://www.linkedin.com/oauth/v2/authorization"):
+            current_app.logger.error(f"[LinkedIn] Invalid redirect URL: {linkedin_auth_url}")
+            return jsonify({"error": "Invalid redirect URL"}), 400
         return redirect(linkedin_auth_url)
     except Exception as e:
         current_app.logger.error(f"[LinkedIn] Error generating auth URL: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/24](https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/24)

To fix the issue, we need to ensure that the `github_user_id` parameter is sanitized and cannot be used to manipulate the redirection URL. A secure approach is to maintain a whitelist of valid `github_user_id` values or encode the parameter in a way that prevents malicious manipulation. Additionally, we can validate the `linkedin_auth_url` to ensure it adheres to the expected structure before performing the redirection.

The best way to fix this is:
1. Validate the `github_user_id` against a whitelist or encode it securely (e.g., using URL encoding or hashing).
2. Ensure the `linkedin_auth_url` is constructed safely and does not allow injection of malicious content.
3. Optionally, log the sanitized `github_user_id` for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
