### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -540,4 +540,5 @@ def preview_linkedin_post():
         preview = generate_preview_post(payload)
         return jsonify({"preview": preview}), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.error(f"An error occurred: {e}", exc_info=True)
+        return jsonify({"error": "An internal error has occurred. Please try again later."}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/22](https://github.com/ajharris/github-linkedin-auto-post/security/code-scanning/22)

To fix the issue, we should avoid exposing the raw exception message to the user. Instead, we can log the exception details on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues using server logs. The changes will involve replacing the `str(e)` in the JSON response with a generic error message and adding a logging statement to capture the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
